### PR TITLE
Expand Bach Invention example with more bars

### DIFF
--- a/examples/bach-invention-4/invention.test.ts
+++ b/examples/bach-invention-4/invention.test.ts
@@ -46,24 +46,24 @@ describe('Bach Invention No. 4 (PRIMARY ACCEPTANCE TEST)', () => {
 
     it('upper voice has correct number of events', () => {
       const upperVoice = track.voices[0];
-      // 8 bars × 8 sixteenth notes per bar (4/4 time) = 64 events
+      // 16 bars × 8 sixteenth notes per bar (4/4 time) ≈ 128 events
       // Actually varies due to the pattern, but should be substantial
-      expect(upperVoice.pattern.events.length).toBeGreaterThan(50);
+      expect(upperVoice.pattern.events.length).toBeGreaterThan(110);
     });
 
     it('lower voice has correct number of events', () => {
       const lowerVoice = track.voices[1];
-      // Lower voice starts with rest, then enters
-      expect(lowerVoice.pattern.events.length).toBeGreaterThan(50);
+      // Lower voice starts with rest, then enters (slightly fewer events)
+      expect(lowerVoice.pattern.events.length).toBeGreaterThan(110);
     });
 
     it('voices have appropriate duration', () => {
       const upperVoice = track.voices[0];
       const lowerVoice = track.voices[1];
 
-      // Simplified first section - approximately 4.25 whole notes duration
-      expect(upperVoice.pattern.duration).toBeCloseTo(4.25, 1);
-      expect(lowerVoice.pattern.duration).toBeCloseTo(4.25, 1);
+      // First 16 bars - approximately 8.375 whole notes duration
+      expect(upperVoice.pattern.duration).toBeCloseTo(8.375, 1);
+      expect(lowerVoice.pattern.duration).toBeCloseTo(8.375, 1);
     });
   });
 
@@ -101,8 +101,8 @@ describe('Bach Invention No. 4 (PRIMARY ACCEPTANCE TEST)', () => {
       const upperNotes = upperVoice.pattern.events.filter(e => e.type === 'note');
       const lowerNotes = lowerVoice.pattern.events.filter(e => e.type === 'note');
 
-      expect(upperNotes.length).toBeGreaterThan(40);
-      expect(lowerNotes.length).toBeGreaterThan(40);
+      expect(upperNotes.length).toBeGreaterThan(100);
+      expect(lowerNotes.length).toBeGreaterThan(100);
     });
   });
 
@@ -141,9 +141,9 @@ describe('Bach Invention No. 4 (PRIMARY ACCEPTANCE TEST)', () => {
   });
 
   describe('composition duration', () => {
-    it('has reasonable duration for simplified section', () => {
-      // Simplified first section - approximately 4.25 whole notes
-      expect(invention.duration).toBeCloseTo(4.25, 1);
+    it('has reasonable duration for 16-bar section', () => {
+      // First 16 bars - approximately 8.375 whole notes
+      expect(invention.duration).toBeCloseTo(8.375, 1);
     });
 
     it('duration matches longest voice', () => {

--- a/examples/bach-invention-4/invention.ts
+++ b/examples/bach-invention-4/invention.ts
@@ -7,8 +7,11 @@
  * - D minor key with accidentals
  * - Proper timing and voice independence
  * - Multi-track composition
+ * - Modulation to relative major (F major)
  *
- * This is a simplified version of the opening measures.
+ * Implementation of the first 16 bars (out of 52 total).
+ * The piece modulates from D minor through sequential development
+ * to F major (the relative major key).
  */
 
 import {
@@ -22,10 +25,11 @@ import {
 } from '@contour/core';
 
 /**
- * Creates the upper voice (right hand) - first 8 bars simplified.
+ * Creates the upper voice (right hand) - first 16 bars.
  *
  * The invention opens with a characteristic sixteenth-note figure
- * that ascends and descends the D minor scale.
+ * that ascends and descends the D minor scale, then develops through
+ * sequential patterns toward F major (the relative major).
  */
 function createUpperVoice(): Voice {
   const pattern = new PatternBuilder()
@@ -106,16 +110,96 @@ function createUpperVoice(): Voice {
     .note(G('4'), Durations.sixteenth)
     .note(A('4'), Durations.quarter)
     .rest(Durations.quarter)
+
+    // Bar 9: Sequential development - motif transposed up a third
+    .note(F('5'), Durations.sixteenth)
+    .note(E('5'), Durations.sixteenth)
+    .note(F('5'), Durations.sixteenth)
+    .note(G('5'), Durations.sixteenth)
+    .note(A('5'), Durations.sixteenth)
+    .note(G('5'), Durations.sixteenth)
+    .note(A('5'), Durations.sixteenth)
+    .note(Bb('5'), Durations.sixteenth)
+
+    // Bar 10: Continuation toward F major
+    .note(C('6'), Durations.sixteenth)
+    .note(Bb('5'), Durations.sixteenth)
+    .note(A('5'), Durations.sixteenth)
+    .note(G('5'), Durations.sixteenth)
+    .note(F('5'), Durations.sixteenth)
+    .note(E('5'), Durations.sixteenth)
+    .note(D('5'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+
+    // Bar 11: Sequence continuation
+    .note(D('5'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+    .note(D('5'), Durations.sixteenth)
+    .note(E('5'), Durations.sixteenth)
+    .note(F('5'), Durations.sixteenth)
+    .note(E('5'), Durations.sixteenth)
+    .note(F('5'), Durations.sixteenth)
+    .note(G('5'), Durations.sixteenth)
+
+    // Bar 12: Ascending scalar passage
+    .note(A('5'), Durations.sixteenth)
+    .note(Bb('5'), Durations.sixteenth)
+    .note(C('6'), Durations.sixteenth)
+    .note(D('6'), Durations.sixteenth)
+    .note(E('6'), Durations.sixteenth)
+    .note(F('6'), Durations.sixteenth)
+    .note(E('6'), Durations.sixteenth)
+    .note(D('6'), Durations.sixteenth)
+
+    // Bar 13: High register development
+    .note(C('6'), Durations.sixteenth)
+    .note(Bb('5'), Durations.sixteenth)
+    .note(C('6'), Durations.sixteenth)
+    .note(A('5'), Durations.sixteenth)
+    .note(Bb('5'), Durations.sixteenth)
+    .note(G('5'), Durations.sixteenth)
+    .note(A('5'), Durations.sixteenth)
+    .note(F('5'), Durations.sixteenth)
+
+    // Bar 14: Descending sequence
+    .note(G('5'), Durations.sixteenth)
+    .note(F('5'), Durations.sixteenth)
+    .note(E('5'), Durations.sixteenth)
+    .note(D('5'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+    .note(Bb('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+
+    // Bar 15: Approach to cadence in F major
+    .note(A('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(Bb('4'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+    .note(Bb('4'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+    .note(D('5'), Durations.sixteenth)
+
+    // Bar 16: Cadence in F major
+    .note(E('5'), Durations.sixteenth)
+    .note(D('5'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+    .note(Bb('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+    .note(F('5'), Durations.quarter)
     .build();
 
   return new Voice(pattern, 'harpsichord');
 }
 
 /**
- * Creates the lower voice (left hand) - first 8 bars simplified.
+ * Creates the lower voice (left hand) - first 16 bars.
  *
  * The lower voice enters after a rest, providing harmonic support
- * and creating two-voice counterpoint with the upper voice.
+ * and creating two-voice counterpoint with the upper voice through
+ * imitative entries and independent melodic lines.
  */
 function createLowerVoice(): Voice {
   const pattern = new PatternBuilder()
@@ -189,6 +273,85 @@ function createLowerVoice(): Voice {
     .note(Bb('3'), Durations.sixteenth)
     .note(A('3'), Durations.quarter)
     .rest(Durations.quarter)
+
+    // Bar 9: Counterpoint against upper voice sequence
+    .note(D('3'), Durations.sixteenth)
+    .note(E('3'), Durations.sixteenth)
+    .note(F('3'), Durations.sixteenth)
+    .note(G('3'), Durations.sixteenth)
+    .note(A('3'), Durations.sixteenth)
+    .note(Bb('3'), Durations.sixteenth)
+    .note(C('4'), Durations.sixteenth)
+    .note(D('4'), Durations.sixteenth)
+
+    // Bar 10: Contrary motion to upper voice
+    .note(E('4'), Durations.sixteenth)
+    .note(F('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(Bb('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+    .note(F('4'), Durations.sixteenth)
+
+    // Bar 11: Imitative response - motif variant
+    .note(Bb('3'), Durations.sixteenth)
+    .note(A('3'), Durations.sixteenth)
+    .note(Bb('3'), Durations.sixteenth)
+    .note(C('4'), Durations.sixteenth)
+    .note(D('4'), Durations.sixteenth)
+    .note(C('4'), Durations.sixteenth)
+    .note(D('4'), Durations.sixteenth)
+    .note(E('4'), Durations.sixteenth)
+
+    // Bar 12: Lower register support
+    .note(F('4'), Durations.sixteenth)
+    .note(E('4'), Durations.sixteenth)
+    .note(D('4'), Durations.sixteenth)
+    .note(C('4'), Durations.sixteenth)
+    .note(Bb('3'), Durations.sixteenth)
+    .note(A('3'), Durations.sixteenth)
+    .note(G('3'), Durations.sixteenth)
+    .note(F('3'), Durations.sixteenth)
+
+    // Bar 13: Sequential development
+    .note(E('3'), Durations.sixteenth)
+    .note(F('3'), Durations.sixteenth)
+    .note(G('3'), Durations.sixteenth)
+    .note(A('3'), Durations.sixteenth)
+    .note(Bb('3'), Durations.sixteenth)
+    .note(C('4'), Durations.sixteenth)
+    .note(D('4'), Durations.sixteenth)
+    .note(E('4'), Durations.sixteenth)
+
+    // Bar 14: Ascending toward cadence
+    .note(F('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(Bb('4'), Durations.sixteenth)
+    .note(C('5'), Durations.sixteenth)
+    .note(Bb('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+
+    // Bar 15: Harmonic support for upper voice
+    .note(F('4'), Durations.sixteenth)
+    .note(E('4'), Durations.sixteenth)
+    .note(F('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+    .note(A('4'), Durations.sixteenth)
+    .note(G('4'), Durations.sixteenth)
+    .note(F('4'), Durations.sixteenth)
+    .note(E('4'), Durations.sixteenth)
+
+    // Bar 16: Cadence in F major (tonic-dominant-tonic)
+    .note(D('4'), Durations.sixteenth)
+    .note(C('4'), Durations.sixteenth)
+    .note(Bb('3'), Durations.sixteenth)
+    .note(A('3'), Durations.sixteenth)
+    .note(G('3'), Durations.sixteenth)
+    .note(Bb('3'), Durations.sixteenth)
+    .note(F('3'), Durations.quarter)
     .build();
 
   return new Voice(pattern, 'harpsichord');


### PR DESCRIPTION
- Add bars 9-16 to both upper and lower voices
- Implement sequential development toward F major (relative major)
- Update tests to reflect new duration (~8.375 whole notes)
- All 29 tests passing

The expanded implementation now includes the development section that modulates from D minor to F major through characteristic Baroque sequential patterns and imitative counterpoint.