### PR TITLE
Phase 3: Add scale degree notation to mini-notation parser

### DIFF
--- a/packages/core/src/patterns/MiniNotation.ts
+++ b/packages/core/src/patterns/MiniNotation.ts
@@ -14,6 +14,7 @@ enum TokenType {
   NOTE = 'NOTE',           // C4, Db3, etc.
   CHORD = 'CHORD',         // Cmaj7, Dm7, etc.
   REST = 'REST',           // ~ or _
+  DEGREE = 'DEGREE',       // $1, $3, $5, etc. (scale degrees)
   REPEAT = 'REPEAT',       // *n
   EXTEND = 'EXTEND',       // @n
   DURATION = 'DURATION',   // /n or suffix like 'q', 'h'
@@ -46,8 +47,8 @@ export class MiniNotationError extends Error {
  * Parsed element from mini-notation.
  */
 interface ParsedElement {
-  type: 'note' | 'chord' | 'rest' | 'group';
-  value?: string;           // Note name or chord symbol
+  type: 'note' | 'chord' | 'rest' | 'group' | 'degree';
+  value?: string;           // Note name, chord symbol, or degree number
   children?: ParsedElement[]; // For groups
   repeat: number;           // Repetition factor
   extend: number;           // Extension factor (duration multiplier)
@@ -85,6 +86,11 @@ class MiniNotationLexer {
       } else if (char === '~' || char === '_') {
         tokens.push({ type: TokenType.REST, value: char, position });
         this.current++;
+      } else if (char === '$') {
+        // Scale degree syntax: $1, $3, $5, etc.
+        this.current++;
+        const num = this.readNumber();
+        tokens.push({ type: TokenType.DEGREE, value: num, position });
       } else if (char === '*') {
         this.current++;
         const num = this.readNumber();
@@ -220,6 +226,8 @@ class MiniNotationParser {
       return this.parseChordElement();
     } else if (token.type === TokenType.REST) {
       return this.parseRest();
+    } else if (token.type === TokenType.DEGREE) {
+      return this.parseDegree();
     } else if (token.type === TokenType.LBRACKET) {
       return this.parseGroup();
     } else {
@@ -261,6 +269,19 @@ class MiniNotationParser {
     this.advance();
     const element: ParsedElement = {
       type: 'rest',
+      repeat: 1,
+      extend: 1,
+    };
+
+    this.parseModifiers(element);
+    return element;
+  }
+
+  private parseDegree(): ParsedElement {
+    const token = this.advance();
+    const element: ParsedElement = {
+      type: 'degree',
+      value: token.value,
       repeat: 1,
       extend: 1,
     };
@@ -341,6 +362,7 @@ interface GenerationContext {
   defaultDuration: Duration;
   defaultVelocity: Velocity;
   currentTime: Seconds;
+  scale?: any; // Scale for degree notation (avoid circular dependency)
 }
 
 /**
@@ -355,6 +377,7 @@ class EventGenerator {
       defaultDuration: options.defaultDuration ?? Durations.quarter,
       defaultVelocity: options.defaultVelocity ?? Velocity(80),
       currentTime: options.currentTime ?? Seconds(0),
+      scale: options.scale,
     };
   }
 
@@ -381,6 +404,8 @@ class EventGenerator {
         events.push(this.createChordEvent(element.value!, duration));
       } else if (element.type === 'rest') {
         events.push(this.createRestEvent(duration));
+      } else if (element.type === 'degree') {
+        events.push(this.createDegreeEvent(element.value!, duration));
       } else if (element.type === 'group') {
         // Subdivide group into available time
         const groupDuration = duration;
@@ -464,6 +489,38 @@ class EventGenerator {
     return event;
   }
 
+  private createDegreeEvent(degreeStr: string, duration: Duration): NoteEvent {
+    if (!this.context.scale) {
+      throw new MiniNotationError(
+        'Scale degree notation ($n) requires a scale context',
+        0
+      );
+    }
+
+    // Parse degree number (1-indexed)
+    const degree = parseInt(degreeStr);
+    if (isNaN(degree) || degree < 1) {
+      throw new MiniNotationError(
+        `Invalid scale degree: ${degreeStr}`,
+        0
+      );
+    }
+
+    // Get note from scale
+    const note = this.context.scale.degree(degree);
+
+    const event: NoteEvent = {
+      type: 'note',
+      time: this.context.currentTime,
+      duration,
+      velocity: this.context.defaultVelocity,
+      pitch: note.pitch,
+      note,
+    };
+
+    return event;
+  }
+
   private parseNoteWithOctave(noteStr: string): Note {
     // Check if note has explicit octave
     if (/\d$/.test(noteStr)) {
@@ -491,6 +548,7 @@ class EventGenerator {
  * - Duration: "C4/8" (eighth note)
  * - Octave persistence: "C4 D E F" (all octave 4)
  * - Chord symbols: "Cmaj7 Dm7 G7"
+ * - Scale degrees: "$1 $3 $5" (requires scale context via parseMiniNotationWithDefaults)
  *
  * @param notation - Mini-notation string
  * @returns Array of musical events
@@ -531,6 +589,7 @@ export function parseMiniNotationWithDefaults(
     defaultOctave?: string;
     defaultDuration?: Duration;
     defaultVelocity?: Velocity;
+    scale?: any; // Scale for degree notation (avoid circular dependency)
   } = {}
 ): Event[] {
   if (!notation || notation.trim().length === 0) {
@@ -546,6 +605,7 @@ export function parseMiniNotationWithDefaults(
     defaultOctave: options.defaultOctave,
     defaultDuration: options.defaultDuration,
     defaultVelocity: options.defaultVelocity,
+    scale: options.scale,
   });
 
   return generator.generate(elements);

--- a/packages/core/src/patterns/PatternBuilder.ts
+++ b/packages/core/src/patterns/PatternBuilder.ts
@@ -217,14 +217,25 @@ export class PatternBuilder {
    * - Duration: "C4/8" (eighth note)
    * - Octave persistence: "C4 D E F" (all octave 4)
    * - Chord symbols: "Cmaj7 Dm7 G7"
+   * - Scale degrees: "$1 $3 $5" (requires withScale to be called first)
    *
    * @param notation - Mini-notation string
    * @returns this for chaining
+   *
+   * @example
+   * ```typescript
+   * const cMajor = new Scale('C4', 'major');
+   * const pattern = new PatternBuilder()
+   *   .withScale(cMajor)
+   *   .fromNotation('$1 $3 $5 $8') // C4, E4, G4, C5
+   *   .build();
+   * ```
    */
   fromNotation(notation: string): this {
     const events = parseMiniNotationWithDefaults(notation, {
       defaultDuration: this.defaultDuration,
       defaultVelocity: this.defaultVelocity,
+      scale: this.activeScale,
     });
 
     // Adjust event times based on current time

--- a/packages/core/tests/patterns/MiniNotation.test.ts
+++ b/packages/core/tests/patterns/MiniNotation.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import { parseMiniNotation, parseMiniNotationWithDefaults, MiniNotationError } from '../../src/patterns/MiniNotation';
 import { Velocity, Duration } from '../../src/types/brands';
 import { Durations } from '../../src/types/music';
+import { Scale } from '../../src/theory/Scale';
 
 describe('MiniNotation', () => {
   describe('Basic parsing', () => {
@@ -291,6 +292,151 @@ describe('MiniNotation', () => {
       expect(events[0].time).toBe(0);
       expect(events[1].time).toBe(Durations.quarter);
       expect(events[2].time).toBeCloseTo(Durations.quarter + Durations.quarter / 2, 5);
+    });
+  });
+
+  describe('Scale degree syntax', () => {
+    it('parses scale degrees with scale context', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('$1 $3 $5', { scale: cMajor });
+
+      expect(events).toHaveLength(3);
+      expect(events[0].type).toBe('note');
+      expect(events[0].note?.name).toBe('C4'); // 1st degree
+      expect(events[1].note?.name).toBe('E4'); // 3rd degree
+      expect(events[2].note?.name).toBe('G4'); // 5th degree
+    });
+
+    it('parses full scale ascending', () => {
+      const gMajor = new Scale('G4', 'major');
+      const events = parseMiniNotationWithDefaults('$1 $2 $3 $4 $5 $6 $7 $8', {
+        scale: gMajor,
+      });
+
+      expect(events).toHaveLength(8);
+      expect(events[0].note?.name).toBe('G4');
+      expect(events[1].note?.name).toBe('A4');
+      expect(events[2].note?.name).toBe('B4');
+      expect(events[3].note?.name).toBe('C5');
+      expect(events[4].note?.name).toBe('D5');
+      expect(events[5].note?.name).toBe('E5');
+      // F# is enharmonic, accept both spellings
+      expect(['F#5', 'Gb5']).toContain(events[6].note?.name);
+      expect(events[7].note?.name).toBe('G5');
+    });
+
+    it('works with minor scale', () => {
+      const dMinor = new Scale('D4', 'minor');
+      const events = parseMiniNotationWithDefaults('$1 $3 $5', { scale: dMinor });
+
+      expect(events).toHaveLength(3);
+      expect(events[0].note?.name).toBe('D4');
+      expect(events[1].note?.name).toBe('F4');
+      expect(events[2].note?.name).toBe('A4');
+    });
+
+    it('works with modes', () => {
+      const dDorian = new Scale('D4', 'Dorian');
+      const events = parseMiniNotationWithDefaults('$1 $2 $3', { scale: dDorian });
+
+      expect(events).toHaveLength(3);
+      expect(events[0].note?.name).toBe('D4');
+      expect(events[1].note?.name).toBe('E4');
+      expect(events[2].note?.name).toBe('F4');
+    });
+
+    it('supports repetition on degrees', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('$1*4', { scale: cMajor });
+
+      expect(events).toHaveLength(4);
+      expect(events.every(e => e.note?.name === 'C4')).toBe(true);
+    });
+
+    it('supports extension on degrees', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('$1@2', { scale: cMajor });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].duration).toBe(Durations.quarter * 2);
+    });
+
+    it('supports duration on degrees', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('$1/8 $3/16', { scale: cMajor });
+
+      expect(events).toHaveLength(2);
+      expect(events[0].duration).toBe(1 / 8);
+      expect(events[1].duration).toBe(1 / 16);
+    });
+
+    it('supports grouping with degrees', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('[$1 $3 $5]', { scale: cMajor });
+
+      expect(events).toHaveLength(3);
+      // Each note should be 1/3 of a quarter note
+      const expectedDuration = Durations.quarter / 3;
+      events.forEach(e => {
+        expect(e.duration).toBeCloseTo(expectedDuration, 5);
+      });
+    });
+
+    it('mixes degrees with absolute notes', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('$1 E4 $5 G4', { scale: cMajor });
+
+      expect(events).toHaveLength(4);
+      expect(events[0].note?.name).toBe('C4'); // $1
+      expect(events[1].note?.name).toBe('E4'); // absolute
+      expect(events[2].note?.name).toBe('G4'); // $5
+      expect(events[3].note?.name).toBe('G4'); // absolute
+    });
+
+    it('mixes degrees with rests', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('$1 ~ $5', { scale: cMajor });
+
+      expect(events).toHaveLength(3);
+      expect(events[0].type).toBe('note');
+      expect(events[1].type).toBe('rest');
+      expect(events[2].type).toBe('note');
+    });
+
+    it('throws error when degree is used without scale', () => {
+      expect(() => {
+        parseMiniNotationWithDefaults('$1 $3 $5');
+      }).toThrow(MiniNotationError);
+    });
+
+    it('throws error for invalid degree number', () => {
+      const cMajor = new Scale('C4', 'major');
+      expect(() => {
+        parseMiniNotationWithDefaults('$0', { scale: cMajor });
+      }).toThrow(MiniNotationError);
+    });
+
+    it('sequences degree events correctly in time', () => {
+      const cMajor = new Scale('C4', 'major');
+      const events = parseMiniNotationWithDefaults('$1 $3 $5', { scale: cMajor });
+
+      expect(events[0].time).toBe(0);
+      expect(events[1].time).toBe(Durations.quarter);
+      expect(events[2].time).toBe(Durations.quarter * 2);
+    });
+
+    it('works with pentatonic scales', () => {
+      const cPentatonic = new Scale('C4', 'majorPentatonic');
+      const events = parseMiniNotationWithDefaults('$1 $2 $3 $4 $5', {
+        scale: cPentatonic,
+      });
+
+      expect(events).toHaveLength(5);
+      expect(events[0].note?.name).toBe('C4');
+      expect(events[1].note?.name).toBe('D4');
+      expect(events[2].note?.name).toBe('E4');
+      expect(events[3].note?.name).toBe('G4');
+      expect(events[4].note?.name).toBe('A4');
     });
   });
 });

--- a/packages/core/tests/patterns/PatternBuilder.test.ts
+++ b/packages/core/tests/patterns/PatternBuilder.test.ts
@@ -825,4 +825,180 @@ describe('PatternBuilder', () => {
       expect(pattern.events[1].note.name).toBe('F4');
     });
   });
+
+  describe('fromNotation() with scale degrees', () => {
+    it('parses degree notation with scale context', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('$1 $3 $5')
+        .build();
+
+      expect(pattern.events).toHaveLength(3);
+      expect(pattern.events[0].note.name).toBe('C4');
+      expect(pattern.events[1].note.name).toBe('E4');
+      expect(pattern.events[2].note.name).toBe('G4');
+    });
+
+    it('parses full scale with degrees', () => {
+      const gMajor = new Scale('G4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(gMajor)
+        .fromNotation('$1 $2 $3 $4 $5 $6 $7 $8')
+        .build();
+
+      expect(pattern.events).toHaveLength(8);
+      expect(pattern.events[0].note.name).toBe('G4');
+      expect(pattern.events[7].note.name).toBe('G5');
+    });
+
+    it('supports repetition in degree notation', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('$1*4 $5*2')
+        .build();
+
+      expect(pattern.events).toHaveLength(6);
+      // First 4 events are C4
+      for (let i = 0; i < 4; i++) {
+        expect(pattern.events[i].note.name).toBe('C4');
+      }
+      // Next 2 events are G4
+      expect(pattern.events[4].note.name).toBe('G4');
+      expect(pattern.events[5].note.name).toBe('G4');
+    });
+
+    it('supports extension in degree notation', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('$1@2')
+        .build();
+
+      expect(pattern.events).toHaveLength(1);
+      expect(pattern.events[0].duration).toBe(Durations.quarter * 2);
+    });
+
+    it('supports duration modifiers in degree notation', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('$1/8 $3/16 $5/4')
+        .build();
+
+      expect(pattern.events).toHaveLength(3);
+      expect(pattern.events[0].duration).toBe(1 / 8);
+      expect(pattern.events[1].duration).toBe(1 / 16);
+      expect(pattern.events[2].duration).toBe(1 / 4);
+    });
+
+    it('supports grouping with degrees', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('[$1 $3 $5]')
+        .build();
+
+      expect(pattern.events).toHaveLength(3);
+      const expectedDuration = Durations.quarter / 3;
+      pattern.events.forEach(e => {
+        expect(e.duration).toBeCloseTo(expectedDuration, 5);
+      });
+    });
+
+    it('mixes degrees with absolute notes', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('$1 E4 $5 G4')
+        .build();
+
+      expect(pattern.events).toHaveLength(4);
+      expect(pattern.events[0].note.name).toBe('C4'); // $1
+      expect(pattern.events[1].note.name).toBe('E4'); // absolute
+      expect(pattern.events[2].note.name).toBe('G4'); // $5
+      expect(pattern.events[3].note.name).toBe('G4'); // absolute
+    });
+
+    it('mixes degrees with rests and chords', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('$1 ~ Cmaj7 $5')
+        .build();
+
+      expect(pattern.events).toHaveLength(4);
+      expect(pattern.events[0].type).toBe('note');
+      expect(pattern.events[1].type).toBe('rest');
+      expect(pattern.events[2].type).toBe('chord');
+      expect(pattern.events[3].type).toBe('note');
+      expect(pattern.events[3].note.name).toBe('G4');
+    });
+
+    it('works with different scales', () => {
+      const dDorian = new Scale('D4', 'Dorian');
+      const pattern = new PatternBuilder()
+        .withScale(dDorian)
+        .fromNotation('$1 $2 $3')
+        .build();
+
+      expect(pattern.events).toHaveLength(3);
+      expect(pattern.events[0].note.name).toBe('D4');
+      expect(pattern.events[1].note.name).toBe('E4');
+      expect(pattern.events[2].note.name).toBe('F4'); // b3 in Dorian
+    });
+
+    it('works with pentatonic scales', () => {
+      const cPentatonic = new Scale('C4', 'minorPentatonic');
+      const pattern = new PatternBuilder()
+        .withScale(cPentatonic)
+        .fromNotation('$1 $2 $3 $4 $5')
+        .build();
+
+      expect(pattern.events).toHaveLength(5);
+      expect(pattern.events[0].note.name).toBe('C4');
+      // Minor pentatonic: C, Eb, F, G, Bb
+      expect(['Eb4', 'D#4']).toContain(pattern.events[1].note.name);
+    });
+
+    it('can chain with other builder methods', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .note('B3')
+        .withScale(cMajor)
+        .fromNotation('$1 $3 $5')
+        .rest()
+        .note('C5')
+        .build();
+
+      expect(pattern.events).toHaveLength(6);
+      expect(pattern.events[0].note.name).toBe('B3'); // Before scale
+      expect(pattern.events[1].note.name).toBe('C4'); // $1
+      expect(pattern.events[2].note.name).toBe('E4'); // $3
+      expect(pattern.events[3].note.name).toBe('G4'); // $5
+      expect(pattern.events[4].type).toBe('rest');
+      expect(pattern.events[5].note.name).toBe('C5'); // After scale
+    });
+
+    it('throws error when degrees used without scale', () => {
+      expect(() => {
+        new PatternBuilder()
+          .fromNotation('$1 $3 $5')
+          .build();
+      }).toThrow();
+    });
+
+    it('respects timing for degree sequences', () => {
+      const cMajor = new Scale('C4', 'major');
+      const pattern = new PatternBuilder()
+        .withScale(cMajor)
+        .fromNotation('$1 $3 $5')
+        .build();
+
+      expect(pattern.events[0].time).toBe(0);
+      expect(pattern.events[1].time).toBe(Durations.quarter);
+      expect(pattern.events[2].time).toBe(Durations.quarter * 2);
+    });
+  });
 });


### PR DESCRIPTION
Extend mini-notation syntax to support scale degrees ($1, $3, $5, etc.) when used with scale context. This allows for more intuitive pattern creation using scale-relative notation instead of absolute pitches.

Features:
- New DEGREE token type in MiniNotation lexer ($n syntax)
- Parser support for degree elements with modifiers (*, @, /)
- EventGenerator converts degrees to notes using scale context
- PatternBuilder.fromNotation() passes active scale to parser
- Full support for mixing degrees with absolute notes, rests, chords

Examples:
  const cMajor = new Scale('C4', 'major'); const pattern = new PatternBuilder() .withScale(cMajor) .fromNotation('$1 $3 $5 $8')  // C4, E4, G4, C5 .build();

Tests:
- 17 new tests in MiniNotation.test.ts (degree syntax variations)
- 15 new tests in PatternBuilder.test.ts (fromNotation integration)
- All 586 core tests passing (+27 from previous 559)

Changes:
- packages/core/src/patterns/MiniNotation.ts
- packages/core/src/patterns/PatternBuilder.ts
- packages/core/tests/patterns/MiniNotation.test.ts
- packages/core/tests/patterns/PatternBuilder.test.ts