### PR TITLE
docs: Add comprehensive music theory documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Contour enables developers to compose music using functional patterns, explore a
 ## Features
 
 - **Functional Composition** - Build music using composable, immutable patterns inspired by TidalCycles
-- **Mini-Notation** - Concise, expressive syntax for rapid pattern creation
+- **Mini-Notation** - Concise, expressive syntax for rapid pattern creation including scale degree notation (`$1 $3 $5`)
+- **Music Theory Integration** - Comprehensive support for scales (15 types), modes, chord voicings (20+ qualities), and progressions
 - **Live Coding** - Perfect for performances with hot-reload and instant feedback
 - **Euclidean Rhythms** - Generate algorithmically interesting patterns using Bjorklund's algorithm
-- **Music Theory Exploration** - Create microtonal music, complex polyrhythms, and algorithmic compositions
+- **Advanced Composition** - Create microtonal music, modal jazz, complex polyrhythms, and algorithmic compositions
 - **Type Safety** - Branded types prevent unit mixing (Hz vs BPM) at compile time
 - **Hot Module Reload** - Instant feedback with graceful audio transitions
 - **Interactive Debug Tools** - Real-time transport inspector, pattern analyzer, and performance monitor
@@ -225,6 +226,19 @@ pattern().fromNotation('C4 E4 G4').build();
 // Advanced features
 pattern().fromNotation('C4*4 ~ [E4 G4] C5@2').build();
 // C4 repeated 4 times, rest, E4/G4 subdivision, C5 held longer
+
+// Scale degree notation
+const cMajor = new Scale('C4', 'major');
+pattern()
+  .withScale(cMajor)
+  .fromNotation('$1 $3 $5 $8')  // C4, E4, G4, C5 (scale degrees)
+  .build();
+
+// Mix degrees with absolute notes and modifiers
+pattern()
+  .withScale(cMajor)
+  .fromNotation('$1*2 E4 [$3 $5] $8@2')
+  .build();
 ```
 
 ### Pattern Algebra
@@ -244,6 +258,209 @@ const p2 = pattern().fromNotation('G4 C5').build();
 p1.stack(p2);      // Play simultaneously
 p1.append(p2);     // Play sequentially
 p1.palindrome();   // Forward then reverse
+```
+
+### Music Theory
+
+Contour includes comprehensive music theory utilities for scales, modes, chords, and progressions:
+
+#### Scales and Modes
+
+Create scales in any key with 15 built-in scale types:
+
+```typescript
+import { Scale } from '@contour/core';
+
+// Major scale
+const cMajor = new Scale('C4', 'major');
+const notes = cMajor.getNotes();  // [C4, D4, E4, F4, G4, A4, B4, C5]
+
+// Minor scales
+const dMinor = new Scale('D4', 'minor');          // Natural minor
+const aHarmonic = new Scale('A4', 'harmonicMinor'); // Harmonic minor
+
+// Greek modes
+const dDorian = new Scale('D4', 'Dorian');
+const ePhrygian = new Scale('E4', 'Phrygian');
+const fLydian = new Scale('F4', 'Lydian');
+const gMixolydian = new Scale('G4', 'Mixolydian');
+const aAeolian = new Scale('A4', 'Aeolian');
+const bLocrian = new Scale('B4', 'Locrian');
+
+// Pentatonic scales
+const cPentatonic = new Scale('C4', 'majorPentatonic');
+const aPentMinor = new Scale('A4', 'minorPentatonic');
+
+// Get specific scale degrees
+const third = cMajor.degree(3);   // E4
+const fifth = cMajor.degree(5);   // G4
+const octave = cMajor.degree(8);  // C5
+
+// Transform scales
+const transposed = cMajor.transpose(2);  // D major
+```
+
+#### Scale Degree Notation
+
+Use `$n` syntax in mini-notation to reference scale degrees:
+
+```typescript
+import { PatternBuilder, Scale } from '@contour/core';
+
+const cMajor = new Scale('C4', 'major');
+
+// Create patterns using scale degrees (1-indexed)
+const pattern = new PatternBuilder()
+  .withScale(cMajor)
+  .fromNotation('$1 $3 $5 $8')  // C4, E4, G4, C5
+  .build();
+
+// Full scale ascending
+const scale = new PatternBuilder()
+  .withScale(cMajor)
+  .fromNotation('$1 $2 $3 $4 $5 $6 $7 $8')
+  .build();
+
+// Degrees support all mini-notation modifiers
+const complex = new PatternBuilder()
+  .withScale(cMajor)
+  .fromNotation('$1*4 ~ [$3 $5] $8@2')
+  .build();
+  // Tonic repeated 4x, rest, third/fifth subdivision, octave held longer
+
+// Mix with absolute notes
+const mixed = new PatternBuilder()
+  .withScale(cMajor)
+  .fromNotation('$1 E4 $5 G4')  // Scale degrees mixed with absolute pitches
+  .build();
+
+// Works with any scale type
+const dorian = new PatternBuilder()
+  .withScale(new Scale('D4', 'Dorian'))
+  .fromNotation('$1 $2 $3')  // D4, E4, F4 (natural 2nd, flat 3rd)
+  .build();
+```
+
+#### Pattern Integration with Scales
+
+Use the `.degrees()` method or convert scales directly to patterns:
+
+```typescript
+// Method 1: PatternBuilder.degrees()
+const pattern = new PatternBuilder()
+  .withScale(cMajor)
+  .degrees([1, 3, 5, 8])  // Array of scale degrees
+  .build();
+
+// Method 2: Scale.pattern()
+const scalePattern = cMajor.pattern([1, 2, 3, 4, 5, 6, 7, 8]);
+
+// Quantize existing patterns to a scale
+const chromaticMelody = pattern().fromNotation('C4 C#4 D4 D#4 E4').build();
+const quantized = chromaticMelody.inScale(cMajor);
+// Snaps all notes to nearest scale degree
+```
+
+#### Chord Voicings
+
+Create and manipulate chord voicings with proper octave spanning:
+
+```typescript
+import { ChordVoicing } from '@contour/core';
+
+// Create chords by quality
+const cMaj7 = ChordVoicing.fromQuality('C4', 'maj7');  // C4, E4, G4, B4
+const dm7 = ChordVoicing.fromQuality('D4', 'm7');      // D4, F4, A4, C5
+const g7 = ChordVoicing.fromQuality('G4', '7');        // G4, B4, D5, F5
+
+// Supported chord qualities: maj, maj7, m, m7, 7, dim, dim7, aug, sus2, sus4,
+//   6, m6, 9, m9, 11, m11, 13, m13, add9, 7sus4, maj9, and more
+
+// Get inversions
+const firstInv = cMaj7.inversion(1);   // E4, G4, B4, C5
+const secondInv = cMaj7.inversion(2);  // G4, B4, C5, E5
+
+// Transform chords
+const transposed = cMaj7.transpose(5);  // F maj7
+
+// Convert to pattern (block chords or arpeggios)
+const blockChord = cMaj7.toPattern(Durations.half, 'block');
+const arpeggio = cMaj7.toPattern(Durations.quarter, 'arpeggio');
+```
+
+#### Chord Progressions
+
+Create timed sequences of chords using Roman numeral notation:
+
+```typescript
+import { ChordProgression } from '@contour/core';
+
+// Create progression with Roman numerals
+const progression = ChordProgression.fromDegrees(
+  cMajor,
+  ['I', 'IV', 'V', 'I'],  // Uppercase = major, lowercase = minor
+  Duration(1.0)            // Duration per chord
+);
+
+// Common progressions
+const jazzTurnaround = ChordProgression.fromDegrees(
+  cMajor,
+  ['I', 'vi', 'ii', 'V'],  // I-vi-ii-V
+  Duration(2.0)
+);
+
+// Minor key progression
+const minorProg = ChordProgression.fromDegrees(
+  new Scale('A4', 'minor'),
+  ['i', 'iv', 'V', 'i'],   // i-iv-V-i in A minor
+  Duration(1.5)
+);
+
+// Convert to pattern
+const blockChords = progression.toPattern('block');      // Block chords
+const arpeggiated = progression.toPattern('arpeggio');  // Arpeggiated
+
+// Transform progressions
+const transposed = progression.transpose(5);  // Up perfect 4th
+const faster = progression.fast(2);           // Double speed
+```
+
+#### Practical Examples
+
+**Modal Jazz Composition:**
+```typescript
+const dDorian = new Scale('D4', 'Dorian');
+
+// Melody using scale degrees
+const melody = new PatternBuilder()
+  .withScale(dDorian)
+  .fromNotation('$1/8 $2/8 $3/4 $2/8 $1/4 ~ $5/8 $3/4')
+  .build();
+
+// Chord progression in Dorian
+const chords = ChordProgression.fromDegrees(
+  dDorian,
+  ['i', 'IV', 'i', 'IV'],  // i-IV vamp common in Dorian
+  Duration(2.0)
+).toPattern('block');
+```
+
+**Algorithmic Composition with Scales:**
+```typescript
+const cPentatonic = new Scale('C4', 'minorPentatonic');
+
+// Generate random walk through pentatonic scale
+const randomMelody = new PatternBuilder()
+  .withScale(cPentatonic)
+  .degrees([1, 3, 5, 3, 2, 5, 1])
+  .build()
+  .fast(2)
+  .every(4, p => p.rev());
+
+// Quantize generative patterns to scale
+const euclideanMelody = Pattern.euclidean(16, 9)
+  .transpose(60)  // Start at C4
+  .inScale(cPentatonic);  // Snap to pentatonic notes
 ```
 
 ### Four-Layer Architecture
@@ -326,13 +543,21 @@ const drums = pattern()
   .fromNotation('C2*4 ~ [E3 G3] C4@2')
   .build();
 
+// Scale degree notation for modal composition
+const cMajor = new Scale('C4', 'major');
+const modalMelody = pattern()
+  .withScale(cMajor)
+  .fromNotation('$1 $2 $3 $5 $8 $5 $3 $1')  // Scale-based melody
+  .build();
+
 // Euclidean rhythms for algorithmic composition
 const rhythm = Pattern.euclidean(16, 5);  // 5 pulses in 16 steps
 const shifted = Pattern.euclidean(8, 3, 2);  // With rotation
 
-// Combine with transformations
+// Combine with transformations and scales
 const generative = Pattern.euclidean(16, 11)
   .transpose(60)  // MIDI note C4
+  .inScale(new Scale('C4', 'minorPentatonic'))  // Quantize to pentatonic
   .fast(2);
 ```
 


### PR DESCRIPTION
Add extensive documentation for the new music theory integration features including scales, modes, chord voicings, chord progressions, and scale degree notation in mini-notation.

Additions:
- New "Music Theory" section in Core Concepts with comprehensive examples
- Scales and Modes: 15 scale types, degree access, transformations
- Scale Degree Notation: $n syntax in mini-notation with all modifiers
- Pattern Integration: degrees(), inScale(), scale.pattern()
- Chord Voicings: fromQuality(), inversions, 20+ chord qualities
- Chord Progressions: Roman numeral notation, toPattern()
- Practical examples for modal jazz and algorithmic composition

Updates:
- Features list highlights scale degree notation and 15 scale types
- Mini-Notation section includes scale degree examples
- Examples section shows scales with Euclidean rhythms

Fixes:
- Corrected Duration vs Seconds types in chord progression examples