### PR TITLE
Remove green scanline animation from index

### DIFF
--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -50,11 +50,6 @@
       }
     }
 
-    @keyframes scanline {
-      0% { transform: translateY(-100%); }
-      100% { transform: translateY(100vh); }
-    }
-
     body {
       font-family: 'DM Mono', monospace;
       background: var(--bg-void);
@@ -81,25 +76,6 @@
       pointer-events: none;
       z-index: 9999;
       opacity: 0.3;
-    }
-
-    /* Animated scanline */
-    body::after {
-      content: '';
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 2px;
-      background: linear-gradient(90deg,
-        transparent,
-        var(--neon-cyan),
-        transparent
-      );
-      opacity: 0.3;
-      animation: scanline 8s linear infinite;
-      pointer-events: none;
-      z-index: 9998;
     }
 
     /* Grid background */


### PR DESCRIPTION
Removed the animated scanline effect that scrolled vertically across the landing page. The static grid background and other visual elements remain unchanged.