### PR TITLE
fix: Complete carousel navigation and click-to-open functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -1096,9 +1096,9 @@ fs.<span class="code-function">writeFileSync</span>(<span class="code-string">'s
 
       function goToSlide(index) {
         currentSlide = index;
-        // Track is 3 slides wide (300%), so each slide is 33.333% of track
-        const slidePercentage = 100 / totalSlides;
-        track.style.transform = `translateX(-${currentSlide * slidePercentage}%)`;
+        // Calculate pixel offset based on slide width
+        const slideWidth = track.querySelector('.carousel-slide').offsetWidth;
+        track.style.transform = `translateX(-${currentSlide * slideWidth}px)`;
 
         // Update indicators
         indicators.forEach((indicator, i) => {


### PR DESCRIPTION
## Summary
- Fix carousel slide navigation to properly move between all 3 screenshots
- Use pixel-based translation for reliable slide positioning
- Add click-to-open functionality so tapping images opens them in new tab
- Add visual feedback (cursor pointer, hover opacity) for clickable images

## Test plan
- [ ] Navigate between screenshots using prev/next buttons
- [ ] Click on indicator dots to jump to specific slides
- [ ] Tap/click on images to open them in new tab
- [ ] Verify auto-play advances slides every 5 seconds
- [ ] Test keyboard navigation with arrow keys
- [ ] Verify swipe gestures work on mobile/touch devices